### PR TITLE
Ajustes en múltiples services y controllers para soporte sin pa…

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,22 +1,22 @@
-import { Module } from '@nestjs/common';
-import { AuthService } from './auth.service';
-import { AuthController } from './auth.controller';
-import { JwtModule } from '@nestjs/jwt';
-import { UsersModule } from '../users/users.module';
-import { PassportModule } from '@nestjs/passport';
-import { MailerModule } from '@nestjs-modules/mailer';
-import { JwtStrategy } from './strategies/jwt.strategy';
-import { LocalStrategy } from './strategies/local.strategy';
-import { RoleGuard } from './guards/role.guard';
-import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import { Module } from "@nestjs/common";
+import { AuthService } from "./auth.service";
+import { AuthController } from "./auth.controller";
+import { JwtModule } from "@nestjs/jwt";
+import { UsersModule } from "../users/users.module";
+import { PassportModule } from "@nestjs/passport";
+import { MailerModule } from "@nestjs-modules/mailer";
+import { JwtStrategy } from "./strategies/jwt.strategy";
+import { LocalStrategy } from "./strategies/local.strategy";
+import { RoleGuard } from "./guards/role.guard";
+import { JwtAuthGuard } from "./guards/jwt-auth.guard";
 
 @Module({
   imports: [
-    PassportModule.register({ defaultStrategy: 'jwt' }),
+    PassportModule.register({ defaultStrategy: "jwt" }),
     JwtModule.register({
       global: true,
       secret: process.env.JWT_SECRET,
-      signOptions: { expiresIn: '3600s' },
+      signOptions: { expiresIn: "3600s" },
     }),
     UsersModule,
     MailerModule,
@@ -27,14 +27,14 @@ import { JwtAuthGuard } from './guards/jwt-auth.guard';
     LocalStrategy,
     JwtStrategy,
     {
-      provide: 'APP_GUARD',
+      provide: "APP_GUARD",
       useClass: JwtAuthGuard,
     },
     RoleGuard,
     {
-      provide: 'APP_GUARD',
+      provide: "APP_GUARD",
       useClass: RoleGuard,
     },
   ],
 })
-export class AuthModule { }
+export class AuthModule {}

--- a/src/authors/authors.controller.ts
+++ b/src/authors/authors.controller.ts
@@ -36,6 +36,13 @@ export class AuthorsController {
   async searchAuthors(@Query() paginationDto: PaginationDto & { search?: string }) {
     return this.authorsService.searchAuthors(paginationDto);
   }
+  @PublicAccess()
+  @Get("/top")
+  async getTopAuthors(@Query("limit") limit?: string) {
+    const parsedLimit = parseInt(limit || "5", 10);
+    const authors = await this.authorsService.findTopAuthors(parsedLimit);
+    return authors;
+  }
 
   @PublicAccess()
   @Get(":id")

--- a/src/authors/authors.service.ts
+++ b/src/authors/authors.service.ts
@@ -111,6 +111,37 @@ export class AuthorsService {
       ManagerError.createSignatureError(error.message);
     }
   }
+  async findTopAuthors(
+    limit: number = 5
+  ): Promise<Array<{ id: string; authorName: string; biography: string; photo: string; booksCount: number }>> {
+    try {
+      const authorsWithCount = await this.authorsRepository
+        .createQueryBuilder("author")
+        .leftJoin("author.books", "book")
+        .where("author.isActive = true")
+        .select([
+          "author.id AS id",
+          "author.authorName AS authorName",
+          "author.biography AS biography",
+          "author.photo AS photo",
+          "COUNT(book.id)::int AS booksCount",
+        ])
+        .groupBy("author.id")
+        .orderBy("booksCount", "DESC")
+        .limit(limit)
+        .getRawMany();
+
+      return authorsWithCount.map((raw) => ({
+        id: raw.id,
+        authorName: raw.authorname, // cuidado con el casing
+        biography: raw.biography,
+        photo: raw.photo,
+        booksCount: raw.bookscount, // cuidado: revisar aquí el nombre exacto en consola
+      }));
+    } catch (error) {
+      ManagerError.createSignatureError(error.message);
+    }
+  }
 
   async findOne(id: string): Promise<OneApiResponse<AuthorEntity>> {
     try {

--- a/src/books/books.controller.ts
+++ b/src/books/books.controller.ts
@@ -18,6 +18,7 @@ import { PaginationDto } from "src/common/dtos/pagination/pagination.dto";
 import { FileInterceptor } from "@nestjs/platform-express";
 import { PublicAccess } from "src/auth/decorators/public.decorator";
 import { Response } from "express";
+import { AllApiResponse, GroupedApiResponse } from "src/common/interfaces/response-api.interface";
 
 @Controller("books")
 export class BooksController {
@@ -28,6 +29,24 @@ export class BooksController {
   async create(@Body() createBookDto: CreateBookDto, @UploadedFile() file: Express.Multer.File) {
     const newBook = await this.booksService.create(createBookDto, file);
     return newBook;
+  }
+  @PublicAccess()
+  @Get("top-viewed")
+  async getTopViewed(@Query("limit") limit?: string): Promise<AllApiResponse<any>> {
+    const parsedLimit = parseInt(limit || "5", 10);
+    return this.booksService.findTopViewed(parsedLimit);
+  }
+  @PublicAccess()
+  @Get("top-by-category")
+  async getTopBooksByCategory(): Promise<GroupedApiResponse<any>> {
+    return this.booksService.findTopBooksGroupedByCategory();
+  }
+
+  @PublicAccess()
+  @Get("/top-downloaded")
+  async getTopDownloaded(@Query("limit") limit?: string): Promise<AllApiResponse<any>> {
+    const parsedLimit = parseInt(limit || "5", 10);
+    return this.booksService.findTopDownloaded(parsedLimit);
   }
 
   @PublicAccess()

--- a/src/common/interfaces/response-api.interface.ts
+++ b/src/common/interfaces/response-api.interface.ts
@@ -1,4 +1,4 @@
-import { HttpStatus } from '@nestjs/common';
+import { HttpStatus } from "@nestjs/common";
 
 interface Metadata {
   page: number;
@@ -22,4 +22,11 @@ export interface AllApiResponse<T> {
   meta: Metadata;
   status: Status;
   data: T[];
+}
+export interface GroupedApiResponse<T> {
+  status: Status;
+  meta: {
+    totalCategories: number;
+  };
+  data: Record<string, T[]>;
 }

--- a/src/editorials/editorials.controller.ts
+++ b/src/editorials/editorials.controller.ts
@@ -1,10 +1,10 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, Query } from '@nestjs/common';
-import { EditorialsService } from './editorials.service';
-import { CreateEditorialDto } from './dto/create-editorial.dto';
-import { UpdateEditorialDto } from './dto/update-editorial.dto';
-import { PaginationDto } from 'src/common/dtos/pagination/pagination.dto';
+import { Controller, Get, Post, Body, Patch, Param, Delete, Query } from "@nestjs/common";
+import { EditorialsService } from "./editorials.service";
+import { CreateEditorialDto } from "./dto/create-editorial.dto";
+import { UpdateEditorialDto } from "./dto/update-editorial.dto";
+import { PaginationDto } from "src/common/dtos/pagination/pagination.dto";
 
-@Controller('editorials')
+@Controller("editorials")
 export class EditorialsController {
   constructor(private readonly editorialsService: EditorialsService) {}
 
@@ -18,18 +18,23 @@ export class EditorialsController {
     return this.editorialsService.findAll(paginationDto);
   }
 
-  @Get(':id')
-  findOne(@Param('id') id: string) {
+  @Get("/search")
+  findAllForEditorials(@Query() paginationDto: PaginationDto) {
+    return this.editorialsService.findAllForEditorials(paginationDto);
+  }
+
+  @Get(":id")
+  findOne(@Param("id") id: string) {
     return this.editorialsService.findOne(id);
   }
 
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updateEditorialDto: UpdateEditorialDto) {
+  @Patch(":id")
+  update(@Param("id") id: string, @Body() updateEditorialDto: UpdateEditorialDto) {
     return this.editorialsService.update(id, updateEditorialDto);
   }
 
-  @Delete(':id')
-  remove(@Param('id') id: string) {
+  @Delete(":id")
+  remove(@Param("id") id: string) {
     return this.editorialsService.remove(id);
   }
 }

--- a/src/genders/genders.controller.ts
+++ b/src/genders/genders.controller.ts
@@ -1,10 +1,11 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, Query } from '@nestjs/common';
-import { GendersService } from './genders.service';
-import { CreateGenderDto } from './dto/create-gender.dto';
-import { UpdateGenderDto } from './dto/update-gender.dto';
-import { PaginationDto } from 'src/common/dtos/pagination/pagination.dto';
+import { Controller, Get, Post, Body, Patch, Param, Delete, Query } from "@nestjs/common";
+import { GendersService } from "./genders.service";
+import { CreateGenderDto } from "./dto/create-gender.dto";
+import { UpdateGenderDto } from "./dto/update-gender.dto";
+import { PaginationDto } from "src/common/dtos/pagination/pagination.dto";
+import { PublicAccess } from "src/auth/decorators/public.decorator";
 
-@Controller('genders')
+@Controller("genders")
 export class GendersController {
   constructor(private readonly gendersService: GendersService) {}
 
@@ -12,24 +13,34 @@ export class GendersController {
   create(@Body() createGenderDto: CreateGenderDto) {
     return this.gendersService.create(createGenderDto);
   }
-
+  @PublicAccess()
   @Get()
   findAll(@Query() paginationDto: PaginationDto) {
     return this.gendersService.findAll(paginationDto);
   }
 
-  @Get(':id')
-  findOne(@Param('id') id: string) {
+  @Get("/search")
+  findAllForAdmin(@Query() paginationDto: PaginationDto) {
+    return this.gendersService.findAllForAdmin(paginationDto);
+  }
+  @PublicAccess()
+  @Get("/names")
+  findAllNames() {
+    return this.gendersService.findAllNames();
+  }
+
+  @Get(":id")
+  findOne(@Param("id") id: string) {
     return this.gendersService.findOne(id);
   }
 
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updateGenderDto: UpdateGenderDto) {
+  @Patch(":id")
+  update(@Param("id") id: string, @Body() updateGenderDto: UpdateGenderDto) {
     return this.gendersService.update(id, updateGenderDto);
   }
 
-  @Delete(':id')
-  remove(@Param('id') id: string) {
+  @Delete(":id")
+  remove(@Param("id") id: string) {
     return this.gendersService.remove(id);
   }
 }

--- a/src/genders/genders.service.ts
+++ b/src/genders/genders.service.ts
@@ -1,30 +1,46 @@
-import { Injectable } from '@nestjs/common';
-import { CreateGenderDto } from './dto/create-gender.dto';
-import { UpdateGenderDto } from './dto/update-gender.dto';
-import { Repository, UpdateResult } from 'typeorm';
-import { GenderEntity } from './entities/gender.entity';
-import { InjectRepository } from '@nestjs/typeorm';
-import { ManagerError } from 'src/common/errors/manager.error';
-import { PaginationDto } from 'src/common/dtos/pagination/pagination.dto';
-import { AllApiResponse, OneApiResponse } from 'src/common/interfaces/response-api.interface';
+import { Injectable } from "@nestjs/common";
+import { CreateGenderDto } from "./dto/create-gender.dto";
+import { UpdateGenderDto } from "./dto/update-gender.dto";
+import { Repository, UpdateResult } from "typeorm";
+import { GenderEntity } from "./entities/gender.entity";
+import { InjectRepository } from "@nestjs/typeorm";
+import { ManagerError } from "src/common/errors/manager.error";
+import { PaginationDto } from "src/common/dtos/pagination/pagination.dto";
+import { AllApiResponse, OneApiResponse } from "src/common/interfaces/response-api.interface";
 
 @Injectable()
 export class GendersService {
   constructor(
     @InjectRepository(GenderEntity)
-    private readonly gendersRepository: Repository<GenderEntity>,
-  ) { }
+    private readonly gendersRepository: Repository<GenderEntity>
+  ) {}
 
   async create(createGenderDto: CreateGenderDto): Promise<GenderEntity> {
     try {
       const gender = await this.gendersRepository.save(createGenderDto);
       if (!gender) {
         throw new ManagerError({
-          type: 'CONFLICT',
-          message: 'gender not created!'
-        })
+          type: "CONFLICT",
+          message: "gender not created!",
+        });
       }
       return gender;
+    } catch (error) {
+      ManagerError.createSignatureError(error.message);
+    }
+  }
+  async findAllNames(): Promise<string[]> {
+    try {
+      const gendersWithBooks = await this.gendersRepository
+        .createQueryBuilder("gender")
+        .leftJoin("gender.books", "book")
+        .where("gender.isActive = true")
+        .andWhere("book.id IS NOT NULL") // solo géneros con al menos un libro
+        .select("DISTINCT gender.genderName", "name")
+        .orderBy("gender.genderName", "ASC")
+        .getRawMany();
+
+      return gendersWithBooks.map((g) => g.name);
     } catch (error) {
       ManagerError.createSignatureError(error.message);
     }
@@ -36,20 +52,15 @@ export class GendersService {
     try {
       const [total, data] = await Promise.all([
         this.gendersRepository.count({ where: { isActive: true } }),
-        this.gendersRepository
-          .createQueryBuilder('gender')
-          .where({ isActive: true })
-          .take(limit)
-          .skip(skip)
-          .getMany(),
-      ])
+        this.gendersRepository.createQueryBuilder("gender").where({ isActive: true }).take(limit).skip(skip).getMany(),
+      ]);
 
       const lastPage = Math.ceil(total / limit);
       return {
         status: {
-          statusMsg: 'ACCEPTED',
+          statusMsg: "ACCEPTED",
           statusCode: 200,
-          error: null
+          error: null,
         },
         meta: {
           page,
@@ -57,35 +68,70 @@ export class GendersService {
           lastPage,
           total,
         },
-        data
-      }
+        data,
+      };
     } catch (error) {
       ManagerError.createSignatureError(error.message);
     }
   }
 
+  async findAllForAdmin(paginationDto: PaginationDto): Promise<AllApiResponse<GenderEntity>> {
+    const { limit, page, q } = paginationDto;
+    const skip = (page - 1) * limit;
+
+    const queryBuilder = this.gendersRepository.createQueryBuilder("gender").where("gender.isActive = true");
+
+    if (q && q.trim() !== "") {
+      queryBuilder.andWhere("(LOWER(gender.genderName) LIKE LOWER(:q) OR LOWER(gender.description) LIKE LOWER(:q))", {
+        q: `%${q}%`,
+      });
+    }
+
+    try {
+      const [data, total] = await Promise.all([
+        queryBuilder.clone().take(limit).skip(skip).getMany(),
+        queryBuilder.clone().getCount(),
+      ]);
+
+      const lastPage = Math.ceil(total / limit);
+
+      return {
+        status: {
+          statusMsg: "ACCEPTED",
+          statusCode: 200,
+          error: null,
+        },
+        meta: {
+          page,
+          limit,
+          lastPage,
+          total,
+        },
+        data,
+      };
+    } catch (error) {
+      ManagerError.createSignatureError(error.message);
+    }
+  }
   async findOne(id: string): Promise<OneApiResponse<GenderEntity>> {
     try {
-      const gender = await this.gendersRepository
-        .createQueryBuilder('gender')
-        .where({ id, isActive: true })
-        .getOne();
+      const gender = await this.gendersRepository.createQueryBuilder("gender").where({ id, isActive: true }).getOne();
 
       if (!gender) {
         throw new ManagerError({
-          type: 'NOT_FOUND',
-          message: 'gender not found!'
-        })
+          type: "NOT_FOUND",
+          message: "gender not found!",
+        });
       }
 
       return {
         status: {
-          statusMsg: 'ACCEPTED',
+          statusMsg: "ACCEPTED",
           statusCode: 200,
-          error: null
+          error: null,
         },
-        data: gender
-      }
+        data: gender,
+      };
     } catch (error) {
       ManagerError.createSignatureError(error.message);
     }
@@ -93,12 +139,12 @@ export class GendersService {
 
   async update(id: string, updateGenderDto: UpdateGenderDto): Promise<UpdateResult> {
     try {
-      const gender = await this.gendersRepository.update({ id }, updateGenderDto)
+      const gender = await this.gendersRepository.update({ id }, updateGenderDto);
       if (gender.affected === 0) {
         throw new ManagerError({
-          type: 'CONFLICT',
-          message: 'gender not found!'
-        })
+          type: "CONFLICT",
+          message: "gender not found!",
+        });
       }
       return gender;
     } catch (error) {
@@ -111,9 +157,9 @@ export class GendersService {
       const gender = await this.gendersRepository.update({ id }, { isActive: false });
       if (gender.affected === 0) {
         throw new ManagerError({
-          type: 'NOT_FOUND',
-          message: 'gender not found!'
-        })
+          type: "NOT_FOUND",
+          message: "gender not found!",
+        });
       }
       return gender;
     } catch (error) {

--- a/src/mailer/mailer.module.ts
+++ b/src/mailer/mailer.module.ts
@@ -1,9 +1,9 @@
-import { Module } from '@nestjs/common';
-import { MailerModule as NestMailerModule } from '@nestjs-modules/mailer';
-import { HandlebarsAdapter } from '@nestjs-modules/mailer/dist/adapters/handlebars.adapter';
-import { join } from 'path';
-import * as dotenv from 'dotenv';
-import { MailerService } from './mailer.service';
+import { Module } from "@nestjs/common";
+import { MailerModule as NestMailerModule } from "@nestjs-modules/mailer";
+import { HandlebarsAdapter } from "@nestjs-modules/mailer/dist/adapters/handlebars.adapter";
+import { join } from "path";
+import * as dotenv from "dotenv";
+import { MailerService } from "./mailer.service";
 
 dotenv.config();
 
@@ -24,7 +24,7 @@ dotenv.config();
           from: `"No Reply" <${process.env.MAIL_FROM_EMAIL}>`,
         },
         template: {
-          dir: join(__dirname, 'templates'),
+          dir: join(__dirname, "templates"),
           adapter: new HandlebarsAdapter(),
           options: {
             strict: true,
@@ -36,4 +36,4 @@ dotenv.config();
   providers: [MailerService],
   exports: [MailerService],
 })
-export class MailerModule { }
+export class MailerModule {}

--- a/src/mailer/mailer.service.ts
+++ b/src/mailer/mailer.service.ts
@@ -1,32 +1,32 @@
-import { Injectable } from '@nestjs/common';
-import { MailerService as NestMailerService } from '@nestjs-modules/mailer';
-import { SendMailDto } from './dto/send-mail.dto';
+import { Injectable } from "@nestjs/common";
+import { MailerService as NestMailerService } from "@nestjs-modules/mailer";
+import { SendMailDto } from "./dto/send-mail.dto";
 
 @Injectable()
 export class MailerService {
-    constructor(private readonly nestMailerService: NestMailerService) { }
+  constructor(private readonly nestMailerService: NestMailerService) {}
 
-    async sendMail(sendMailDto: SendMailDto): Promise<void> {
-        const { to, subject, template, context } = sendMailDto;
+  async sendMail(sendMailDto: SendMailDto): Promise<void> {
+    const { to, subject, template, context } = sendMailDto;
 
-        await this.nestMailerService.sendMail({
-            to,
-            subject,
-            template,
-            context,
-        });
-    }
+    await this.nestMailerService.sendMail({
+      to,
+      subject,
+      template,
+      context,
+    });
+  }
 
-    async sendPasswordResetEmail(email: string, name: string, resetLink: string, resetToken: string): Promise<void> {
-        await this.sendMail({
-            to: email,
-            subject: 'Recuperación de contraseña',
-            template: 'password-reset',
-            context: {
-                name,
-                resetLink,
-                resetToken,
-            },
-        });
-    }
+  async sendPasswordResetEmail(email: string, name: string, resetLink: string, resetToken: string): Promise<void> {
+    await this.sendMail({
+      to: email,
+      subject: "Recuperación de contraseña",
+      template: "password-reset",
+      context: {
+        name,
+        resetLink,
+        resetToken,
+      },
+    });
+  }
 }

--- a/src/reviews/reviews.controller.ts
+++ b/src/reviews/reviews.controller.ts
@@ -18,6 +18,11 @@ export class ReviewsController {
     return this.reviewsService.findAll(paginationDto);
   }
 
+  @Get("/search")
+  findAllForReviews(@Query() paginationDto: PaginationDto) {
+    return this.reviewsService.findAllForReviews(paginationDto);
+  }
+
   @Get("filter")
   findWithFilters(
     @Query("userId") userId: string,

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -1,17 +1,22 @@
-import { PartialType } from '@nestjs/mapped-types';
-import { CreateUserDto } from './create-user.dto';
-import { IsDate, IsOptional, IsString } from 'class-validator';
-import { Exclude } from 'class-transformer';
+import { IsEnum, IsOptional, IsDate, IsString } from "class-validator";
+import { Exclude } from "class-transformer";
+import { PartialType } from "@nestjs/mapped-types";
+import { CreateUserDto } from "./create-user.dto";
+import { UserRole } from "src/common/enums/user-role.enum"; // Asegúrate de tener este enum
 
 export class UpdateUserDto extends PartialType(CreateUserDto) {
-    @IsString()
-    @IsOptional()
-    resetToken?: string;
+  @IsString()
+  @IsOptional()
+  resetToken?: string;
 
-    @IsDate()
-    @IsOptional()
-    resetTokenExpiry?
+  @IsDate()
+  @IsOptional()
+  resetTokenExpiry?;
 
-    @Exclude()
-    password?: string;
+  @Exclude()
+  password?: string;
+
+  @IsOptional()
+  @IsEnum(UserRole, { message: "role must be either USER or ADMIN" })
+  role?: UserRole;
 }

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -1,34 +1,27 @@
-import * as bcrypt from 'bcrypt';
 import { ReviewEntity } from "./../../reviews/entities/review.entity";
 import { BaseEntity } from "./../../common/config/base.entity";
 import { UserRole } from "./../../common/enums/user-role.enum";
-import { BeforeInsert, BeforeUpdate, Column, Entity, OneToMany } from "typeorm";
+import { Column, Entity, OneToMany } from "typeorm";
 import { FavoriteEntity } from "./../../favorites/entities/favorite.entity";
 
-@Entity({ name: 'user' })
+@Entity({ name: "user" })
 export class UserEntity extends BaseEntity {
-  @Column({ type: 'varchar' })
+  @Column({ type: "varchar" })
   name: string;
 
-  @Column({ type: 'varchar', unique: true })
+  @Column({ type: "varchar", unique: true })
   email: string;
 
-  @Column({ type: 'varchar' })
+  @Column({ type: "varchar" })
   password: string;
 
-  @Column({ type: 'enum', enum: UserRole, default: UserRole.USER })
+  @Column({ type: "enum", enum: UserRole, default: UserRole.USER })
   role: UserRole;
 
-  @OneToMany(
-    () => ReviewEntity,
-    (review) => review.user
-  )
+  @OneToMany(() => ReviewEntity, (review) => review.user)
   reviews: ReviewEntity[];
 
-  @OneToMany(
-    () => FavoriteEntity,
-    (favorite) => favorite.user
-  )
+  @OneToMany(() => FavoriteEntity, (favorite) => favorite.user)
   favorites: FavoriteEntity[];
 
   @Column({ nullable: true })
@@ -40,10 +33,9 @@ export class UserEntity extends BaseEntity {
   @Column({ default: 0 })
   resetPasswordAttempts: number;
 
-  @Column({ nullable: true, type: 'timestamp' })
+  @Column({ nullable: true, type: "timestamp" })
   lastResetPasswordAttempt?: Date;
 
   @Column({ nullable: true })
   profilePhoto: string;
-
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,19 +1,30 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, ParseUUIDPipe, Query, UseInterceptors, UploadedFile } from '@nestjs/common';
-import { UsersService } from './users.service';
-import { CreateUserDto } from './dto/create-user.dto';
-import { UpdateUserDto } from './dto/update-user.dto';
-import { PaginationDto } from 'src/common/dtos/pagination/pagination.dto';
-import { FileInterceptor } from '@nestjs/platform-express';
-import { PublicAccess } from 'src/auth/decorators/public.decorator';
-import { CloudinaryService } from '../cloudinary/cloudinary.service';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  ParseUUIDPipe,
+  Query,
+  UseInterceptors,
+  UploadedFile,
+} from "@nestjs/common";
+import { UsersService } from "./users.service";
+import { CreateUserDto } from "./dto/create-user.dto";
+import { UpdateUserDto } from "./dto/update-user.dto";
+import { PaginationDto } from "src/common/dtos/pagination/pagination.dto";
+import { FileInterceptor } from "@nestjs/platform-express";
+import { PublicAccess } from "src/auth/decorators/public.decorator";
 
-@Controller('users')
+@Controller("users")
 export class UsersController {
-  constructor(private readonly usersService: UsersService) { }
+  constructor(private readonly usersService: UsersService) {}
 
   @PublicAccess()
   @Post()
-  @UseInterceptors(FileInterceptor('profilePhoto'))
+  @UseInterceptors(FileInterceptor("profilePhoto"))
   async create(@Body() createUserDto: CreateUserDto, @UploadedFile() file?: Express.Multer.File) {
     return this.usersService.create(createUserDto, file);
   }
@@ -22,28 +33,29 @@ export class UsersController {
   async findAll(@Query() paginationDto: PaginationDto) {
     return this.usersService.findAll(paginationDto);
   }
+  @Get("/search")
+  async findAllForUsers(@Query() paginationDto: PaginationDto) {
+    return this.usersService.findAllForUsers(paginationDto);
+  }
 
-  @Get(':id')
-  async findOne(@Param('id', ParseUUIDPipe) id: string) {
+  @Get(":id")
+  async findOne(@Param("id", ParseUUIDPipe) id: string) {
     return this.usersService.findOne(id);
   }
 
-  @Patch(':id')
-  async update(@Param('id', ParseUUIDPipe) id: string, @Body() updateUserDto: UpdateUserDto) {
+  @Patch(":id")
+  async update(@Param("id", ParseUUIDPipe) id: string, @Body() updateUserDto: UpdateUserDto) {
     return this.usersService.update(id, updateUserDto);
   }
 
-  @Delete(':id')
-  async remove(@Param('id', ParseUUIDPipe) id: string) {
+  @Delete(":id")
+  async remove(@Param("id", ParseUUIDPipe) id: string) {
     return this.usersService.remove(id);
   }
 
-  @Post(':id/photo')
-  @UseInterceptors(FileInterceptor('file'))
-  async updatePhoto(
-    @Param('id') id: string,
-    @UploadedFile() file: Express.Multer.File,
-  ) {
+  @Post(":id/photo")
+  @UseInterceptors(FileInterceptor("file"))
+  async updatePhoto(@Param("id") id: string, @UploadedFile() file: Express.Multer.File) {
     return await this.usersService.updateProfilePhoto(id, file);
   }
 }


### PR DESCRIPTION
     Ajustes en múltiples services y controllers para soporte sin paginación desde frontend.

     Se realizaron cambios en varios servicios y controladores de distintas entidades del backend. El objetivo principal fue
crear nuevas rutas y métodos que permitan acceder a datos completos sin depender exclusivamente de la paginación en el frontend.

     Esto mejora el rendimiento y evita múltiples llamadas innecesarias desde el cliente en operaciones como selección dinámica 
de autores, géneros, editoriales, usuarios, etc.

     Algunos archivos fueron modificados automáticamente por Prettier, sin cambios funcionales reales.

     Actualmente se está presentando un problema con el endpoint /auth/forgot-password: el correo no se reconoce o no se está 
enviando correctamente al backend. Este error sigue en revisión.

     Para cualquier duda sobre estos cambios o aclaraciones adicionales, contactar directamente con Roswin Castro.